### PR TITLE
Remove all duplicate tags at once

### DIFF
--- a/source/src/inject/inject.js
+++ b/source/src/inject/inject.js
@@ -43,13 +43,13 @@ function add() {
             hours++;
         }
     }
-    
+
     _timer.textContent = (hours ? (hours > 9 ? hours : "0" + hours) : "00") + ":" + (minutes ? (minutes > 9 ? minutes : "0" + minutes) : "00") + ":" + (seconds > 9 ? seconds : "0" + seconds);
-    
+
     if ( _timer.textContent === '00:15:00' ) {
       $('#timer').css('color', 'red');
     }
-  
+
     timer();
 }
 function timer() {
@@ -72,18 +72,18 @@ var current_time,
  existing_items;
 
 $('button.e-btn--3d.-color-primary, button.e-btn--3d.-color-destructive').on('click', function(e) {
-    
+
     if( $(this).is('.e-btn--3d.-color-primary.-size-l.-width-full') ) {
-       if( $('#item_item_attributes_attributes_5_select_value').val() === 'Unrated' ) { 
+       if( $('#item_item_attributes_attributes_5_select_value').val() === 'Unrated' ) {
             alert('Documentation cannot be unrated');
             return false;
         }
     }
-    
+
     e.stopPropagation();
-    
+
     action = $(this).is(approve_button) ? 'approved' : 'rejected';
-    
+
     // TODO: Set currentState of timer with localStorage to avoid starting from 0 if the page reloads.
     current_time = $("#timer").text();
     existing_items = JSON.parse( localStorage.getItem('allItems') ) || [];
@@ -100,20 +100,20 @@ function removeLocalStorage() {
   var url = $('.header-right-container').children('a').attr('href');
 
   $('.header-right-container').children('a').addClass('exit');
-  
+
   $('.exit').on('click', function(e) {
     var data = JSON.parse( localStorage.getItem('allItems') ),
     downloadable_data,
     file_id = Math.random().toString(36).substr(2, 9),
     data_arr = [];
-    
+
     if(data !== null) {
         e.preventDefault();
-          for(var i = 0; i < data.length; i++) { 
-            downloadable_data = 
+          for(var i = 0; i < data.length; i++) {
+            downloadable_data =
                 i + " — " + " Name: " + data[i][0].item_name + "\n\n" +
-                
-                "ID: " + data[i][0].id + "\n" + 
+
+                "ID: " + data[i][0].id + "\n" +
                 "URL: " + "http://themeforest.net" + data[i][0].item_url + "\n" +
                 "Time Reviewing: " + data[i][0].current_time + "\n" +
                 "Action: " + data[i][0].action + "\n\n" +
@@ -122,7 +122,7 @@ function removeLocalStorage() {
             data_arr.push(downloadable_data);
           }
     }
-    
+
     //console.log(data_arr);
     // TODO: file name should be `tf_review_report_` + date to find it easily.
     console.save(data_arr.join('\n'), 'tf_review_report_' + file_id + '.txt');
@@ -135,7 +135,7 @@ removeLocalStorage();
 
 function makeListOfAttributes( list ) {
   var mappedList;
-  
+
   if( list.is('select#category') ) {
     mappedList = list.children().map(function() {
     var str = $(this).text().replace(/\s+\-\s+/g,"");
@@ -174,7 +174,7 @@ function highlightTags() {
       }
 
       var existingTags = _.uniq(compatibleAndTagsArr);
- 
+
   tags.each( function(i, el) {
         var str = el.innerText.replace(/\s+/g, ''),
             firstWord = getFirstWord(el.innerText);
@@ -184,8 +184,27 @@ function highlightTags() {
             $(el).parent().addClass('highlight');
           }
         }
-        
+
     });
+
+    // Check if we have duplicates
+    if( existingTags.length !== 0 ){
+
+      var tagsInput = $('#tags_tagsinput'),
+          duplicateTag = $( "span.tag.highlight" );
+
+      // append to end of list a button "remove duplicates"
+      tagsInput.append('<span class="btn">Remove duplicates</span>');
+
+      // remove all 'highlight'/duplicate tags at once
+      $('#tags_tagsinput span.btn').on('click', function(){
+        duplicateTag.remove();
+        // We don't need the button anymore so let's get rid of it
+        $('#tags_tagsinput span.btn').remove();
+      });
+
+    }
+    
 }
 highlightTags();
 


### PR DESCRIPTION
I think the problem with the highlight going away from all tags when only one is clicked is because of a conflict in the native dashboard script. It looks like the way it was setup was to remove all classes from a tag element which is also removing all `highlight` classes as well (without actually removing the class from the list).

As a workaround, I've added the follow changes to `highlightTags()` which will add a button for the reviewer to remove all of the highlighted tags at once. 

![screen shot 2017-03-01 at 7 42 29 am](https://cloud.githubusercontent.com/assets/872479/23462246/a510ba38-fe52-11e6-9a01-3cd09240ab9a.png)

![screen shot 2017-03-01 at 7 42 53 am](https://cloud.githubusercontent.com/assets/872479/23462254/b0d033a8-fe52-11e6-9e40-4ca36c7b08f3.png)

This might need to be tested in a live review because I didn't check it all the way through to approval/rejection. In other words, I'm not sure if, once those tags are removed from the unordered list, if the dashboard recognizes that in the final data send.

