### PR TITLE
Display user account notes in review dashboard

### DIFF
--- a/proofing_tool/src/inject/inject.css
+++ b/proofing_tool/src/inject/inject.css
@@ -20,7 +20,7 @@ div.tagsinput span.tag.highlight {
 }
 
 #tags_tagsinput:last-child {
-  
+
 }
 
 /* tag 0.3.6 */
@@ -55,7 +55,7 @@ ul li a.toggle {
   padding: .75em;
   border-radius: 0.15em;
   transition: background .3s ease;
-  
+
   margin-bottom: 10px;
   background: #c7c7c7;
   color: inherit;
@@ -92,4 +92,13 @@ li.category {
   background: grey;
   color: white;
   margin-top: 0px;
+}
+
+/** User Notes **/
+#user-notes .post-avatar__badges {
+  display: none;
+}
+
+#user-notes .note {
+  clear: both;
 }

--- a/proofing_tool/src/inject/inject.css
+++ b/proofing_tool/src/inject/inject.css
@@ -95,13 +95,21 @@ li.category {
 }
 
 /** User Notes **/
-#user-notes .post-avatar__badges {
+#user-notes .user-post__poster {
   display: none;
 }
 
 #user-notes .note {
   clear: both;
-  display: block;
+  display: inline-block;
+  width: 500px;
+  word-break: break-all;
+  word-wrap: break-word;
+  margin-bottom: 1em;
+}
+
+#user-notes .note:last-child {
+  display: none;
 }
 
 #user-notes a.e-btn {

--- a/proofing_tool/src/inject/inject.css
+++ b/proofing_tool/src/inject/inject.css
@@ -101,4 +101,12 @@ li.category {
 
 #user-notes .note {
   clear: both;
+  display: block;
+}
+
+#user-notes a.e-btn {
+  clear: both;
+  float: left;
+  color: white;
+  margin: 1em 0;
 }

--- a/proofing_tool/src/inject/inject.js
+++ b/proofing_tool/src/inject/inject.js
@@ -257,11 +257,14 @@ function highlightTags() {
         userID = $('a[title="author profile page"]').text(),
         userNotesPage = envatoMarket + userID + '/notes',
 
+        // Cache DOM element
+        proofingSidebar = $( ".sidebar-proofing" ),
+
         // Create our new request
         xhr = new XMLHttpRequest();
 
     // Add a div for the notes displayed
-    $( ".sidebar-proofing" ).append( '<h3>User Notes</h3><div id="user-notes"></div>' );
+    proofingSidebar.append( '<h3>User Notes</h3><div id="user-notes"></div>' );
 
     // Open the user's notes page
     xhr.open( 'GET', userNotesPage, true);
@@ -271,8 +274,11 @@ function highlightTags() {
       // Check for a successful response
       if( xhr.readyState === XMLHttpRequest.DONE && xhr.status === 200 ) {
 
-        var response = xhr.responseText;
-        var notes = $( response ).find( 'h2.underlined' ).nextUntil( '.page-controls' );
+        var response = xhr.responseText,
+            notes = $( response ).find( 'h2.underlined' ).nextUntil( '.page-controls' ),
+
+            // Cache DOM element
+            userNotesWrap = $('#user-notes');
 
         // Loop through the returned data object
         for ( var key in notes ){
@@ -280,9 +286,9 @@ function highlightTags() {
 
             // Limits number of notes shown and display button to user notes page
             if( key == 5 ){
-              $('#user-notes').append('<a class ="e-btn" href="'  + userNotesPage + '" target="_blank">View More User Notes</a>');
+              userNotesWrap.append('<a class ="e-btn" href="'  + userNotesPage + '" target="_blank">View More User Notes</a>');
             } else {
-              $('#user-notes').append('<div class="note">' + notes[key].innerHTML + '</div>');
+              userNotesWrap.append('<div class="note">' + notes[key].innerHTML + '</div>');
             }
 
           }

--- a/proofing_tool/src/inject/inject.js
+++ b/proofing_tool/src/inject/inject.js
@@ -277,8 +277,14 @@ function highlightTags() {
         // Loop through the returned data object
         for ( var key in notes ){
           if( typeof( notes[key].innerHTML) != 'undefined' ){
-            // Display each note
-            $('#user-notes').append('<div class="note">' + notes[key].innerHTML + '</div>');
+
+            // Limits number of notes shown and display button to user notes page
+            if( key == 5 ){
+              $('#user-notes').append('<a class ="e-btn" href="'  + userNotesPage + '" target="_blank">View More User Notes</a>');
+            } else {
+              $('#user-notes').append('<div class="note">' + notes[key].innerHTML + '</div>');
+            }
+
           }
         }
 

--- a/proofing_tool/src/inject/inject.js
+++ b/proofing_tool/src/inject/inject.js
@@ -124,9 +124,9 @@ function setLocalStorage() {
     existing_items;
 
   $('button.e-btn--3d.-color-primary, button.e-btn--3d.-color-destructive').on('click', function(e) {
-    
+
     if ( $(this).is('.e-btn--3d.-color-primary.-size-l.-width-full')) {
-      
+
       if ($('#item_item_attributes_attributes_5_select_value').val() === 'Unrated' ) {
         alert('Documentation cannot be unrated');
         return false;
@@ -134,7 +134,7 @@ function setLocalStorage() {
     }
 
     e.stopPropagation();
-    
+
 
     action = $(this).is(approve_button) ? 'approved' : 'rejected';
 
@@ -250,6 +250,53 @@ function highlightTags() {
 
       var existingTags = _.uniq(compatibleAndTagsArr);
 
+  function userNotes() {
+
+    // Get the users notes page
+    var envatoMarket = 'https://themeforest.net/user/',
+        userID = $('a[title="author profile page"]').text(),
+        userNotesPage = envatoMarket + userID + '/notes',
+
+        // Create our new request
+        xhr = new XMLHttpRequest();
+
+    // Add a div for the notes displayed
+    $( ".sidebar-proofing" ).append( '<h3>User Notes</h3><div id="user-notes"></div>' );
+
+    // Open the user's notes page
+    xhr.open( 'GET', userNotesPage, true);
+
+    xhr.onreadystatechange = function() {
+
+      // Check for a successful response
+      if( xhr.readyState === XMLHttpRequest.DONE && xhr.status === 200 ) {
+
+        var response = xhr.responseText;
+        var notes = $( response ).find( 'h2.underlined' ).nextUntil( '.page-controls' );
+
+        // Loop through the returned data object
+        for ( var key in notes ){
+          if( typeof( notes[key].innerHTML) != 'undefined' ){
+            // Display each note
+            $('#user-notes').append('<div class="note">' + notes[key].innerHTML + '</div>');
+          }
+        }
+
+      }
+    };
+    xhr.send();
+
+  }
+  userNotes();
+
+  // invoking improveSelect on document.ready
+  $(function() {
+    function improveSelect() {
+      $('#category').select2();
+    }
+    improveSelect();
+  });
+
       var highlightOnRemove = function() {
         findExistingTag();
       };
@@ -289,7 +336,7 @@ $(function() {
   function improveSelect() {
     $('#category').select2();
   }
- // invoking improveSelect on document.ready 
+ // invoking improveSelect on document.ready
   improveSelect();
 });
 

--- a/proofing_tool/src/inject/inject.js
+++ b/proofing_tool/src/inject/inject.js
@@ -252,16 +252,17 @@ function highlightTags() {
 
   function userNotes() {
 
-    // Get the users notes page
     var envatoMarket = 'https://themeforest.net/user/',
         userID = $('a[title="author profile page"]').text(),
-        userNotesPage = envatoMarket + userID + '/notes',
 
-        // Cache DOM element
-        proofingSidebar = $( ".sidebar-proofing" ),
+    // Construct the user's notes page
+    userNotesPage = envatoMarket + userID + '/notes',
 
-        // Create our new request
-        xhr = new XMLHttpRequest();
+    // Cache DOM element
+    proofingSidebar = $( ".sidebar-proofing" ),
+
+    // Create our new request
+    xhr = new XMLHttpRequest();
 
     // Add a div for the notes displayed
     proofingSidebar.append( '<h3>User Notes</h3><div id="user-notes"></div>' );
@@ -277,11 +278,12 @@ function highlightTags() {
         var response = xhr.responseText,
             notes = $( response ).find( 'h2.underlined' ).nextUntil( '.page-controls' ),
 
-            // Cache DOM element
-            userNotesWrap = $('#user-notes');
+        // Cache DOM element
+        userNotesWrap = $('#user-notes');
 
         // Loop through the returned data object
         for ( var key in notes ){
+
           if( typeof( notes[key].innerHTML) != 'undefined' ){
 
             // Limits number of notes shown and display button to user notes page

--- a/proofing_tool/src/inject/inject.js
+++ b/proofing_tool/src/inject/inject.js
@@ -250,59 +250,6 @@ function highlightTags() {
 
       var existingTags = _.uniq(compatibleAndTagsArr);
 
-  function userNotes() {
-
-    var envatoMarket = 'https://themeforest.net/user/',
-        userID = $('a[title="author profile page"]').text(),
-
-    // Construct the user's notes page
-    userNotesPage = envatoMarket + userID + '/notes',
-
-    // Cache DOM element
-    proofingSidebar = $( ".sidebar-proofing" ),
-
-    // Create our new request
-    xhr = new XMLHttpRequest();
-
-    // Add a div for the notes displayed
-    proofingSidebar.append( '<h3>User Notes</h3><div id="user-notes"></div>' );
-
-    // Open the user's notes page
-    xhr.open( 'GET', userNotesPage, true);
-
-    xhr.onreadystatechange = function() {
-
-      // Check for a successful response
-      if( xhr.readyState === XMLHttpRequest.DONE && xhr.status === 200 ) {
-
-        var response = xhr.responseText,
-            notes = $( response ).find( 'h2.underlined' ).nextUntil( '.page-controls' ),
-
-        // Cache DOM element
-        userNotesWrap = $('#user-notes');
-
-        // Loop through the returned data object
-        for ( var key in notes ){
-
-          if( typeof( notes[key].innerHTML) != 'undefined' ){
-
-            // Limits number of notes shown and display button to user notes page
-            if( key == 5 ){
-              userNotesWrap.append('<a class ="e-btn" href="'  + userNotesPage + '" target="_blank">View More User Notes</a>');
-            } else {
-              userNotesWrap.append('<div class="note">' + notes[key].innerHTML + '</div>');
-            }
-
-          }
-        }
-
-      }
-    };
-    xhr.send();
-
-  }
-  userNotes();
-
   // invoking improveSelect on document.ready
   $(function() {
     function improveSelect() {
@@ -343,6 +290,59 @@ function highlightTags() {
   });
 }
 highlightTags();
+
+function userNotes() {
+
+  var envatoMarket = 'https://themeforest.net/user/',
+      userID = $('a[title="author profile page"]').text(),
+
+  // Construct the user's notes page
+  userNotesPage = envatoMarket + userID + '/notes',
+
+  // Cache DOM element
+  proofingSidebar = $( ".sidebar-proofing" ),
+
+  // Create our new request
+  xhr = new XMLHttpRequest();
+
+  // Add a div for the notes displayed
+  proofingSidebar.append( '<h3>User Notes</h3><div id="user-notes"></div>' );
+
+  // Open the user's notes page
+  xhr.open( 'GET', userNotesPage, true);
+
+  xhr.onreadystatechange = function() {
+
+    // Check for a successful response
+    if( xhr.readyState === XMLHttpRequest.DONE && xhr.status === 200 ) {
+
+      var response = xhr.responseText,
+          notes = $( response ).find( 'h2.underlined' ).nextUntil( '.page-controls' ),
+
+      // Cache DOM element
+      userNotesWrap = $('#user-notes');
+
+      // Loop through the returned data object
+      for ( var key in notes ){
+
+        if( typeof( notes[key].innerHTML) != 'undefined' ){
+
+          // Limits number of notes shown and display button to user notes page
+          if( key == 5 ){
+            userNotesWrap.append('<a class ="e-btn" href="'  + userNotesPage + '" target="_blank">View More User Notes</a>');
+          } else {
+            userNotesWrap.append('<div class="note">' + notes[key].innerHTML + '</div>');
+          }
+
+        }
+      }
+
+    }
+  };
+  xhr.send();
+
+}
+userNotes();
 
 // This plugin improves the `category` select list on the proofing page
 // It adds a search box to find categories easily


### PR DESCRIPTION
Hi Ivor!

This is a quick POC for displaying author account notes. These will just be the notes added by the support team or automatically generated by the system (ie. username changes) and not item specific notes (ie. past item reviews and updates).

I've positioned it at the bottom of the right sidebar but honestly didn't spend much time thinking about UX or anything like that:

![screen shot 2017-04-10 at 6 37 16 pm](https://cloud.githubusercontent.com/assets/872479/24886838/2591ca50-1e1d-11e7-8e74-7e4411872487.png)

If you want to incorporate it, I can probably make some updates to enhance it, make it more efficient, and prettier but it's probably a good place to start as it is.